### PR TITLE
Usability improvements to the create_invoice step & initial setup in setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -145,7 +145,7 @@ Here is configuration guidance for specific goals. Travel and financial goals ha
 * Requires a Stripe key for the `create_invoice` tool. Set this in the `STRIPE_API_KEY` environment variable in .env
     * It's free to sign up and get a key at [Stripe](https://stripe.com/)
         * Set permissions for read-write on: `Credit Notes, Invoices, Customers and Customer Sessions`
-    * If you're lazy go to `tools/create_invoice.py` and replace the `create_invoice` function with the mock `create_invoice_example` that exists in the same file.
+    * If you don't have a Stripe key, comment out the STRIPE_API_KEY in the .env file, and a dummy invoice will be created in `tools/create_invoice.py`
 
 ### Goal: Find a Premier League match, book train tickets to it and invoice the user for the cost (Replay 2025 Keynote)
 - `AGENT_GOAL=goal_match_train_invoice` - Focuses on Premier League match attendance with train booking and invoice generation

--- a/setup.md
+++ b/setup.md
@@ -145,7 +145,7 @@ Here is configuration guidance for specific goals. Travel and financial goals ha
 * Requires a Stripe key for the `create_invoice` tool. Set this in the `STRIPE_API_KEY` environment variable in .env
     * It's free to sign up and get a key at [Stripe](https://stripe.com/)
         * Set permissions for read-write on: `Credit Notes, Invoices, Customers and Customer Sessions`
-    * If you don't have a Stripe key, comment out the STRIPE_API_KEY in the .env file, and a dummy invoice will be created in `tools/create_invoice.py`
+    * If you don't have a Stripe key, comment out the STRIPE_API_KEY in the .env file, and a dummy invoice will be created rather than a Stripe invoice. The function can be found in `tools/create_invoice.py`
 
 ### Goal: Find a Premier League match, book train tickets to it and invoice the user for the cost (Replay 2025 Keynote)
 - `AGENT_GOAL=goal_match_train_invoice` - Focuses on Premier League match attendance with train booking and invoice generation

--- a/tools/create_invoice.py
+++ b/tools/create_invoice.py
@@ -69,15 +69,3 @@ def create_invoice(args: dict) -> dict:
             "invoiceURL": "https://pay.example.com/invoice/12345",
             "reference": "INV-12345",
         }
-
-def create_invoice_example(args: dict) -> dict:
-    """
-    This is an example implementation of the CreateInvoice tool
-    Doesn't call any external services, just returns a dummy response
-    """
-    print("[CreateInvoice] Creating invoice with:", args)
-    return {
-        "invoiceStatus": "generated",
-        "invoiceURL": "https://pay.example.com/invoice/12345",
-        "reference": "INV-12345",
-    }


### PR DESCRIPTION
Currently, if the user does not add a real stripe api key to the .env file, the workflow/chat will get stuck at the 'create_invoice' step, because it bypasses the 'else' block due to a dummy api key in the .env file. The `create_invoice_example` function is also redundant with the else block. I removed the example function from creat_invoice.py and edited the setup.md file to let users know they need to either reference a stripe api key, or comment it out to generate an example invoice