### PR TITLE
chore: add support for devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "name": "Temporal AI Agentic Demo",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-extra/features/poetry:2": {},
+    "ghcr.io/devcontainers/features/python:1": {},
+    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {},
+    "ghcr.io/mrsimonemms/devcontainers/tcld:1": {}
+  },
+  "forwardPorts": [
+    5173,
+	  7233,
+    8000,
+	  8233
+  ],
+  "containerEnv": {
+    "VITE_HOST": "0.0.0.0"
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     open: true,
+    host: process.env.VITE_HOST ?? 'localhost',
   },
 });


### PR DESCRIPTION
Ship the codebase to include the [dev environment](https://containers.dev).

Only code change required was to add an option envvar in the Vite setup - by default, it doesn't allow access outside the container.