### PR TITLE
frontend ui error configurable timeout

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,17 @@
 const API_BASE_URL = 'http://127.0.0.1:8000';
 
+const resolveRequestTimeout = () => {
+    const env = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+    const configured = env?.VITE_API_TIMEOUT_MS;
+    const parsed = Number.parseInt(configured, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+    }
+    return 15000;
+};
+
+const REQUEST_TIMEOUT_MS = resolveRequestTimeout(); // default to 15s, overridable via Vite env
+
 class ApiError extends Error {
     constructor(message, status) {
         super(message);
@@ -19,12 +31,31 @@ async function handleResponse(response) {
     return response.json();
 }
 
+async function fetchWithTimeout(url, options = {}, timeout = REQUEST_TIMEOUT_MS) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+        return await fetch(url, { ...options, signal: controller.signal });
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            throw new ApiError('Request timed out', 408);
+        }
+        throw error;
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
 export const apiService = {
     async getConversationHistory() {
         try {
-            const res = await fetch(`${API_BASE_URL}/get-conversation-history`);
+            const res = await fetchWithTimeout(`${API_BASE_URL}/get-conversation-history`);
             return handleResponse(res);
         } catch (error) {
+            if (error instanceof ApiError) {
+                throw error;
+            }
             throw new ApiError(
                 'Failed to fetch conversation history',
                 error.status || 500
@@ -38,7 +69,7 @@ export const apiService = {
         }
 
         try {
-            const res = await fetch(
+            const res = await fetchWithTimeout(
                 `${API_BASE_URL}/send-prompt?prompt=${encodeURIComponent(message)}`,
                 { 
                     method: 'POST',
@@ -49,6 +80,9 @@ export const apiService = {
             );
             return handleResponse(res);
         } catch (error) {
+            if (error instanceof ApiError) {
+                throw error;
+            }
             throw new ApiError(
                 'Failed to send message',
                 error.status || 500
@@ -58,7 +92,7 @@ export const apiService = {
 
     async startWorkflow() {
         try {
-            const res = await fetch(
+            const res = await fetchWithTimeout(
                 `${API_BASE_URL}/start-workflow`,
                 { 
                     method: 'POST',
@@ -69,6 +103,9 @@ export const apiService = {
             );
             return handleResponse(res);
         } catch (error) {
+            if (error instanceof ApiError) {
+                throw error;
+            }
             throw new ApiError(
                 'Failed to start workflow',
                 error.status || 500
@@ -78,7 +115,7 @@ export const apiService = {
 
     async confirm() {
         try {
-            const res = await fetch(`${API_BASE_URL}/confirm`, { 
+            const res = await fetchWithTimeout(`${API_BASE_URL}/confirm`, { 
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'
@@ -86,6 +123,9 @@ export const apiService = {
             });
             return handleResponse(res);
         } catch (error) {
+            if (error instanceof ApiError) {
+                throw error;
+            }
             throw new ApiError(
                 'Failed to confirm action',
                 error.status || 500


### PR DESCRIPTION
Frontend has default 15s of inactivity (e.g. worker down), and it's more easily configurable via an env var VITE_API_TIMEOUT_MS